### PR TITLE
Feat: 채티 설정 추가

### DIFF
--- a/backend/app/routes/chat_routes.py
+++ b/backend/app/routes/chat_routes.py
@@ -4,7 +4,7 @@ from openai import OpenAI
 from openai.types.chat import ChatCompletion
 from app.utils import token_required
 from dotenv import load_dotenv
-from ..models import db, Chatbot, FaceImage
+from ..models import db, Chatbot, FaceImage, User
 
 load_dotenv()
 bp = Blueprint('chat_routes', __name__, url_prefix='/api/chat')
@@ -13,15 +13,23 @@ client = OpenAI(
     api_key=os.environ.get("OPENAI_API_KEY"),
 )
 
-def summarize_text(dialog):
+# 대화 요약 
+def summarize_text(dialog, user_id):
+    user = User.query.filter_by(id=user_id).first()
+    user_nickname = user.nickname
+
     response = client.chat.completions.create(
         model="gpt-3.5-turbo",
         messages=[
-            {"role": "system", "content": "다음의 대화를 요약해 주세요."},
+            {"role": "system", "content": (
+                f"다음 대화를 요약하세요. 아래 형식을 따르세요:\n"
+                f"감정: {user_nickname}님의 감정을 딱 한 단어로 적어주세요\n"
+                f"Chatty가 {user_nickname}님에게 위로를 건넨 방식이나 말을 한 문장 이내로 설명해주세요"
+            )},
             {"role": "user", "content": dialog}
         ],
-        temperature=0.7,
-        max_tokens=15
+        temperature=0.1,
+        max_tokens=200
     )
     summary = response.choices[0].message.content.strip()
     return summary
@@ -32,21 +40,35 @@ def chat():
     try:
         data = request.json
         user_message = data.get('message')
+        
+       # 상담 시 사용자 닉네임 사용 
+        user_id = request.current_user['sub']
+        user = User.query.filter_by(id=user_id).first()
+        user_nickname = user.nickname
+
+        # 초기 응답 요청인지 확인
+        if "초기 응답 요청" in user_message:
+            system_content = (
+                f"'안녕하세요 {user_nickname}님, 저는 {user_nickname}님의 감정을 케어해주는 심리 상담 챗봇, '채티'입니다.'로 심리 상담의 시작을 알리세요"
+            )
+        else:
+            system_content = (
+                f"사용자의 이름은 {user_nickname}입니다. "
+                "인사를 생략하고 바로 심리 상담을 시작해주세요."
+                "사용자가 행복한 경우 공감의 말을 건네며 행복 이외에 다른 감정을 느끼고 있지는 않은지 확인하세요. 또한, 사용자가 감정을 자각하고 관리할 수 있게 도와주세요."
+                "사용자가 화난, 혐오스러운, 두려운, 슬픈 경우에는 사용자의 감정에 맞는 위로의 말을 건네고 사용자가 자신의 감정을 해소하고 관리하는 능력을 기를 수 있는 대답을 하세요."
+                "사용자가 놀란 경우, 부정적인 의미의 놀라움이므로, 사용자의 감정에 맞는 위로의 말을 건네고 사용자가 감정을 스스로 관리할 수 있게 도와주세요."
+                "상황에 맞는 이모티콘을 적절하게 사용하여 대답을 생성해주세요."
+            )
 
         # OpenAI Chat Completion 요청
         response: ChatCompletion = client.chat.completions.create(
-            # GPT 모델 이름 지정
             model="gpt-3.5-turbo",
             messages=[
-                {
-                    "role": "user",
-                    "content": user_message,
-                },
-                {
-                    "role": "system",
-                    "content": "채티는 사용자의 감정을 케어해주는 심리 상담 챗봇입니다. 사용자는 화남(버럭), 혐오(disgust), 두려움(fear), 행복(행복), 슬픔(sad), 놀람(surprise), 중립(neutral) 중 하나의 감정을 가지고 있을 것이며, 채티는 그 감정을 해소하기 위한 심리 상담을 제공합니다.사용자의 감정이 행복, 중립일 경우에는 해당 감정에 맞게 공감의 말을 건네며 무슨 일이 있었는지 묻습니다. 사용자의 감정이 화남, 혐오, 두려움, 슬픔, 놀람일 경우에는 해당 감정에 맞는 위로의 말을 건네고 무슨 일이 있었는지 묻습니다. 채티는 사용자와의 상호작용을 통해 감정을 케어하는 대화를 주고 받으며, 이모티콘을 적절히 활용합니다. 항상 친절하고 이해심 있게 대답하며, 사용자의 기분을 배려합니다.",
-                }
-            ]
+                {"role": "system", "content": system_content},
+                {"role": "user", "content": user_message},
+            ],
+            temperature=0.6
         )
 
         # 응답에서 텍스트 추출
@@ -64,8 +86,8 @@ def save_chat():
         dialog = data.get('dialog')
         user_id = request.current_user['sub']  
 
-        # 대화 요약
-        summary = summarize_text(dialog)
+        # 대화 저장 시 요약
+        summary = summarize_text(dialog, user_id)
 
         latest_faceimage = FaceImage.query.filter_by(user_id=user_id).order_by(FaceImage.uploaded_at.desc()).first()
 
@@ -108,4 +130,62 @@ def review():
         return jsonify({"message": "피드백 저장 완료"}), 200
 
     except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    
+
+@bp.route('/list', methods=['GET'])
+@token_required
+def get_chat_history():
+    try:
+        user_id = request.current_user['sub']
+        chats = Chatbot.query.filter_by(user_id=user_id).order_by(Chatbot.date.desc()).all()
+        
+        chat_list = [
+            {
+                "id": chat.id,
+                "summary": chat.summary,
+                "date": chat.date.strftime('%Y-%m-%d %H:%M'),
+                "image": f'http://localhost:5000/api/face_image/download/{chat.faceimage_id}' if chat.faceimage_id else None
+            }
+            for chat in chats
+        ]
+        
+        return jsonify(chat_list), 200
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+@bp.route('/list/<int:chat_id>', methods=['GET'])
+@token_required
+def get_chat_by_id(chat_id):
+    try:
+        chat = Chatbot.query.filter_by(id=chat_id).first()
+
+        if chat is None:
+            return jsonify({"error": "해당 ID에 대한 대화 기록을 찾을 수 없습니다."}), 404
+
+        return jsonify({
+            "dialog": chat.dialog.split('\n'), 
+            "date": chat.date.strftime('%Y-%m-%d %H:%M')
+        }), 200
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+@bp.route('/delete/<int:chat_id>', methods=['DELETE'])
+@token_required
+def delete_chat(chat_id):
+    try:
+        chat = Chatbot.query.filter_by(id=chat_id).first()
+
+        if chat is None:
+            return jsonify({"error": "해당 ID에 대한 대화 기록을 찾을 수 없습니다."}), 404
+
+        db.session.delete(chat)
+        db.session.commit()
+
+        return jsonify({"message": "대화 기록이 성공적으로 삭제되었습니다."}), 200
+
+    except Exception as e:
+        db.session.rollback()
         return jsonify({"error": str(e)}), 500

--- a/frontend/src/pages/ChatPage/ChatPage.js
+++ b/frontend/src/pages/ChatPage/ChatPage.js
@@ -13,6 +13,7 @@ const ChatPage = () => {
   const [message, setMessage] = useState('');
   const [chatHistory, setChatHistory] = useState([]);
   const [dateTime, setDateTime] = useState('');
+  const [initialMessageSent, setInitialMessageSent] = useState(false);
   const { dominantEmotionKorean } = location.state || {};
 
   const chatContainerRef = useRef(null); 
@@ -30,7 +31,8 @@ const ChatPage = () => {
   }, [chatHistory]); 
 
   useEffect(() => {
-    if (!dominantEmotionKorean) return;
+    // 초기 응답은 1번만 요청할 수 있도록 제한 
+    if (!dominantEmotionKorean || initialMessageSent) return;
 
     // 초기 응답 생성 
     const fetchInitialResponse = async () => {
@@ -38,13 +40,14 @@ const ChatPage = () => {
         const response = await axios.post('http://localhost:5000/api/chat', { message: dominantEmotionKorean });
         const gptResponse = response.data.response;
         setChatHistory([{ sender: 'gpt', text: gptResponse }]); 
+        setInitialMessageSent(true);
       } catch (error) {
         console.error('초기 응답을 받을 수 없습니다:', error);
       }
     };
 
     fetchInitialResponse();
-  }, [dominantEmotionKorean]);
+  }, [dominantEmotionKorean, initialMessageSent]);
 
   const handleFinish = async () => {
     try {

--- a/frontend/src/pages/ChatPage/ChatPage.module.css
+++ b/frontend/src/pages/ChatPage/ChatPage.module.css
@@ -1,5 +1,6 @@
 .root {
     height: 100vh;
+    overflow-y: auto;
 }
 
 .headerContainer {
@@ -39,17 +40,6 @@
     margin-left: auto;
     margin-right: 10px;
     font-size: 14px;
-}
-
-::-webkit-scrollbar {
-    width: 3px;
-}
-
-::-webkit-scrollbar-thumb {
-    background: rgba(224, 224, 224, 1);
-    border-color: 2.5px solid transparent;
-    border-radius: 10px;
-    background-clip: padding-box;
 }
 
 .chatContainer {

--- a/frontend/src/pages/PicAnalyzePage/PicAnalyzePage.js
+++ b/frontend/src/pages/PicAnalyzePage/PicAnalyzePage.js
@@ -20,10 +20,9 @@ const PicAnalyzePage = () => {
   const filteredEmotions = { ...emotions };
   console.log('감정 분석 결과:', emotions);
 
-  // neutral을 제외한 가장 높은 감정 찾기
   delete filteredEmotions.neutral;
   const dominantEmotion = Object.keys(filteredEmotions).reduce((a, b) => filteredEmotions[a] > filteredEmotions[b] ? a : b);
-  const dominantEmotionKorean = keywordMap[dominantEmotion] + '심리상담해줘';
+  const dominantEmotionKorean = "이것은 초기 응답 요청 메세지입니다. 사용자는 " + keywordMap[dominantEmotion] + "라는 감정을 느끼고 있습니다.";
 
   const handleStartChat = () => {
       navigate('/chat', { state: { dominantEmotionKorean } })


### PR DESCRIPTION
### 작업 이유
- 채팅을 시작하였을 때, 인사를 여러 번 하거나 계속해서 무슨 일이 있었는지만 묻는 질문을 출력함 
- 이모티콘 대신 직접 '(이모티콘을 적절히 활용)' 이라는 문구를 출력하거나 감정 키워드를 맥락에 맞게 해석하지 않음
- 채팅 저장 시에 함께 저장되는 대화 내용 요약이 낮은 max token 값에 의해 한 문장도 채 저장되지 않았음

###  해결 방안
- 조건문으로 초기 응답인지 구별해 인사는 한 번만 하도록 변경
- 키워드의 의미를 명시하고 키워드별 응답의 가이드를 조금 더 구체적으로 제시함 
- 대화 내용 요약의 내용이 매번 달라지기 때문에 max token 값을 늘리고 통일성을 위해 형식을 지정함

